### PR TITLE
Probably a typo, shouldn't this be "camera"?

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See that circled icon? That's a muted microphone. Click to unmute.
 
 ### Using Lync?
 
-In Lync, this means your phone and mic are turned off.
+In Lync, this means your cam and mic are turned off.
 
 ![image](images/lync.png "Lync")
 


### PR DESCRIPTION
Used the abbreviated form "cam" so it is consistent with the rest of the text that uses the word in this form.